### PR TITLE
Fix tuple expression in type annotation

### DIFF
--- a/src/aposteriori/data_prep/create_frame_data_set.py
+++ b/src/aposteriori/data_prep/create_frame_data_set.py
@@ -145,7 +145,7 @@ class Codec:
 
     def encode_gaussian_atom(
         self, atom_label: str, modifiers_triple: t.Tuple[float, float, float]
-    ) -> (np.ndarray, int):
+    ) -> tuple[np.ndarray, int]:
         """
         Encodes atom as a 3x3 gaussian with length of encoder length. Only the
         C, N and O atoms are represented in gaussian form. If Ca and Cb are
@@ -1255,7 +1255,7 @@ def _select_pdb_chain(
     verbosity: int,
     return_chain_path: bool = True,
     nmr_state: int = None,
-) -> (pathlib.Path, ampal.Assembly):
+) -> tuple[pathlib.Path, ampal.Assembly]:
     """
     Select a chain from a pdb file. The chain will remove the original pdb file.
     At the moment we only support the selection of one chain at the time, meaning


### PR DESCRIPTION
Fix error thrown byu VSCode: 

"Tuple expression not allowed in type annotation
Use tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union type"